### PR TITLE
Configure iphone 8 framebuffer

### DIFF
--- a/src/modules/linux/linux.c
+++ b/src/modules/linux/linux.c
@@ -98,7 +98,8 @@ int linux_dtree_overlay(char *boot_args)
     key = dt_get_prop("device-tree", "target-type", NULL);
     if (!strcmp(key, "N61") || // 6
         !strcmp(key, "N71") || !strcmp(key, "N71m") || // 6S
-        !strcmp(key, "D10") || !strcmp(key, "D101"))   // 7
+        !strcmp(key, "D10") || !strcmp(key, "D101") || // 7
+        !strcmp(key, "D20") || !strcmp(key, "D201"))   // 8
         width = gBootArgs->Video.v_width + 2;
     else if (!strcmp(key, "N56") || // 6 Plus
              !strcmp(key, "N66") || !strcmp(key, "N66m") || // 6S Plus


### PR DESCRIPTION
Same configuration as the iphone 7/6s framebuffer.
Tested on iphone 8 global (D20), and I assume the iphone 8 gsm (D201) would be the same.