### PR TITLE
modules/linux: Fix TZ/FW region reserve

### DIFF
--- a/src/modules/linux/linux.c
+++ b/src/modules/linux/linux.c
@@ -177,7 +177,7 @@ int linux_dtree_overlay(char *boot_args)
     if (gBootArgs->physBase > 0x800000000)
     {
         /* Reserve TZ/low FW regions and such */
-        node1 = fdt_add_subnode(fdt, node, "memory@800000000");
+        node1 = fdt_add_subnode(fdt, node, "/memory@800000000");
         if (node1 < 0)
         {
             iprintf("Failed to reserve TZ/FW region");


### PR DESCRIPTION
Tried on N53AP (A1457, A7), without the / it fails adding the node.